### PR TITLE
Tuning Prep + Clang support

### DIFF
--- a/src/datagen.cpp
+++ b/src/datagen.cpp
@@ -54,9 +54,6 @@ void threadFunction(int numGames, int threadID) {
         dumpToArray(output, result, fenVector);
     }
 }
-
-// idk what to use here lol
-constexpr uint8_t threadCount = 5;
 constexpr int moveLimit = 1000;
 // manages the games
 double runGame(Engine &engine, std::vector<std::string>& fenVector, Board board) {

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1,12 +1,25 @@
 #include "globals.h"
-#include "external/incbin.h"
 #include "eval.h"
+
+#ifdef _MSC_VER
+#define SP_MSVC
+#pragma push_macro("_MSC_VER")
+#undef _MSC_VER
+#endif
+
+#define INCBIN_PREFIX g_
+#include "external/incbin.h"
+
+#ifdef SP_MSVC
+#pragma pop_macro("_MSC_VER")
+#undef SP_MSVC
+#endif
 
 // this is my first time doing anything with neural networks, or anything with pointers, so code here might be a bit questionable to look at
 
 namespace {
-    INCBIN(networkData, "../src/nets/clarity_net006.nnue");
-    const Network *network = reinterpret_cast<const Network *>(gnetworkDataData);
+    INCBIN(network, "../src/nets/clarity_net006.nnue");
+    const Network *network = reinterpret_cast<const Network *>(g_networkData);
 }
 
 void Accumulator::initialize(std::span<const int16_t, layer1Size> bias) {

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -55,11 +55,13 @@ std::string toLongAlgebraic(Move move) {
 
 // calculates the reductions used for LMR, ran on startup
 std::array<std::array<uint8_t, 218>, 50> reductions;
+double lmrBase = 0.77;
+double lmrMultiplier = 0.42;
 
 void calculateReductions() {
     for(int depth = 0; depth < 50; depth++) {
         for(int move = 0; move < 218; move++) {
-            reductions[depth][move] = uint8_t(0.77 + log(depth) * log(move) * 0.42);
+            reductions[depth][move] = uint8_t(lmrBase + log(depth) * log(move) * lmrMultiplier);
         }
     }
 }

--- a/src/globals.h
+++ b/src/globals.h
@@ -41,10 +41,6 @@ enum Pieces {
 constexpr int Black = 0;
 constexpr int White = 8;
 
-// piece values left over from a long time ago
-constexpr int mg_value[6] = {64, 271, 299, 375, 769, 0};
-constexpr int eg_value[6] = {112, 351, 361, 627, 1187, 0};
-
 extern std::array<std::array<uint8_t, 218>, 50> reductions;
 
 // structs and stuff
@@ -139,8 +135,18 @@ std::vector<std::string> split(const std::string string, const char seperator);
 void sortMoves(std::array<int, 256> &values, std::array<Move, 256> &moves, int numMoves);
 void incrementalSort(std::array<int, 256> &values, std::array<Move, 256> &moves, int numMoves, int i);
 int flipIndex(int index);
+void calculateReductions();
 uint64_t getPassedPawnMask(int square, int colorToMove);
 extern std::array<uint64_t, 64> squareToBitboard;
+
+// Tunable Parameters
+extern double lmrBase;
+extern double lmrMultiplier;
+extern int hardBoundDivisor;
+extern int softBoundFractionNumerator;
+extern int softBoundFractionDenominator;
+extern double softBoundMultiplier;
+extern int defaultMovesToGo;
 // conthist hehe
 using CHEntry = std::array<std::array<std::array<int16_t, 64>, 7>, 2>;
 using CHTable = std::array<std::array<std::array<CHEntry, 64>, 7>, 2>;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -9,8 +9,6 @@ constexpr int historyCap = 16384;
 int MVV_value[6] = {112, 351, 361, 627, 1187, 0};
 int SEE_value[6] = {112, 351, 361, 627, 1187, 0};
 
-constexpr int depthLimit = 100;
-
 // Tunable Values
 int ASP_BaseDelta = 25;
 double ASP_DeltaMultiplier = 1.5;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -35,10 +35,8 @@ int SPR_DepthCondition = 8;
 int SPR_CaptureThreshold = -90;
 int SPR_QuietThreshold = -50;
 
-int NMP_Adder = 1;
-int NMP_Divisor = 3; 
-int NMP_Subtractor = 2;
-int NMP_DepthCondition = 2;
+int NMP_Divisor = 200; 
+int NMP_Subtractor = 3;
 
 int badCaptureScore = -500000;
 
@@ -371,10 +369,10 @@ int Engine::negamax(Board &board, int depth, int alpha, int beta, int ply, bool 
     // Null Move Pruning (NMP)
     // Things to test: !isPV, alternate formulas, etc
     // "I could probably detect zugzwang here but ehhhhh" -Me, a few months ago
-    if(nmpAllowed && depth >= NMP_DepthCondition && !inCheck && staticEval >= beta) {
+    if(nmpAllowed && !inCheck && staticEval >= beta) {
         stack[ply].ch_entry = &conthistTable[0][0][0];
         board.changeColor();
-        const int score = -negamax(board, depth - (depth+NMP_Adder)/NMP_Divisor - NMP_Subtractor, 0-beta, 1-beta, ply + 1, false);
+        const int score = -negamax(board, depth - 3 - depth / 3 - std::min((staticEval - beta) / NMP_Divisor, NMP_Subtractor), 0-beta, 1-beta, ply + 1, false);
         board.undoChangeColor();
         if(score >= beta) {
             return score;

--- a/src/search.h
+++ b/src/search.h
@@ -5,11 +5,43 @@
 
 constexpr int mateScore = -10000000;
 
+extern int ASP_BaseDelta;
+extern double ASP_DeltaMultiplier;
+extern int ASP_DepthCondition;
+
+extern int MVV_VictimScoreMultiplier;
+
+extern int FirstKillerScore;
+extern int SecondKillerScore;
+
+extern int RFP_DepthCondition;
+extern int RFP_Multiplier;
+
+extern int IIR_DepthCondition;
+
+extern int FP_DepthCondition;
+extern int FP_Base;
+extern int FP_Multiplier;
+
+extern int LMP_DepthCondition;
+extern int LMP_Base;
+
+extern int SPR_DepthCondition;
+extern int SPR_CaptureThreshold;
+extern int SPR_QuietThreshold;
+
+extern int NMP_Adder;
+extern int NMP_Divisor; 
+extern int NMP_Subtractor;
+extern int NMP_DepthCondition;
+
+extern int badCaptureScore;
+
 struct StackEntry {
     // conthist!
     CHEntry *ch_entry;
-    // killer moves, 3 per ply
-    std::array<Move, 3> killers;
+    // killer moves, 2 per ply
+    std::array<Move, 2> killers;
     // static eval used for improving
     int staticEval;
     bool inCheck;

--- a/src/search.h
+++ b/src/search.h
@@ -30,10 +30,8 @@ extern int SPR_DepthCondition;
 extern int SPR_CaptureThreshold;
 extern int SPR_QuietThreshold;
 
-extern int NMP_Adder;
 extern int NMP_Divisor; 
 extern int NMP_Subtractor;
-extern int NMP_DepthCondition;
 
 extern int badCaptureScore;
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -9,6 +9,12 @@
     There are things not supported here though, such as go nodes, and quite a few options
 */
 
+int hardBoundDivisor = 2;
+int softBoundFractionNumerator = 3;
+int softBoundFractionDenominator = 4;
+double softBoundMultiplier = 0.6;
+int defaultMovesToGo = 20;
+
 Board board("8/8/8/8/8/8/8/8 w - - 0 1");
 Engine engine;
 
@@ -30,7 +36,8 @@ void runBench(int depth) {
 
 // sets options, though currently just the hash size
 void setOption(const std::vector<std::string>& bits) {
-    if(bits[2] == "Hash") {
+    std::string name = bits[2];
+    if(name == "Hash") {
         int newSizeMB = std::stoi(bits[4]);
         int newSizeB = newSizeMB * 1024 * 1024;
         // this should be 16 bytes
@@ -39,6 +46,64 @@ void setOption(const std::vector<std::string>& bits) {
         int newSizeEntries = newSizeB / entrySizeB;
         //std::cout << log2(newSizeEntries);
         engine.resizeTT(newSizeEntries);
+    } else if(name == "lmrBase") {
+        lmrBase = std::stod(bits[4]) / 100;
+        calculateReductions();
+    } else if(name == "lmrMultiplier") {
+        lmrMultiplier = std::stod(bits[4]) / 100;
+        calculateReductions();
+    } else if(name == "hardBoundDivisor") {
+        hardBoundDivisor = std::stoi(bits[4]);
+    } else if(name == "softBoundFractionNumerator") {
+        softBoundFractionNumerator = std::stoi(bits[4]);
+    } else if(name == "softBoundFractionDenominator") {
+        softBoundFractionDenominator = std::stoi(bits[4]);
+    } else if(name == "softBoundMultiplier") {
+        softBoundMultiplier = std::stod(bits[4]) / 100;
+    } else if(name == "defaultMovesToGo") {
+        defaultMovesToGo = std::stoi(bits[4]);
+    } else if(name == "ASP_BaseDelta") {
+        ASP_BaseDelta = std::stoi(bits[4]);
+    } else if(name == "ASP_DeltaMultiplier") {
+        ASP_DeltaMultiplier = std::stod(bits[4]) / 10;
+    } else if(name == "ASP_DepthCondition") {
+        ASP_DepthCondition = std::stoi(bits[4]);
+    } else if(name == "MVV_VictimScoreMultiplier") {
+        MVV_VictimScoreMultiplier = std::stoi(bits[4]);
+    } else if(name == "FirstKillerScore") {
+        FirstKillerScore = std::stoi(bits[4]) * 1000;
+    } else if(name == "SecondKillerScore") {
+        SecondKillerScore = std::stoi(bits[4]) * 1000;
+    } else if(name == "RFP_DepthCondition") {
+        RFP_DepthCondition = std::stoi(bits[4]);
+    } else if(name == "RFP_Multiplier") {
+        RFP_Multiplier = std::stoi(bits[4]);
+    } else if(name == "IIR_DepthCondition") {
+        IIR_DepthCondition = std::stoi(bits[4]);
+    } else if(name == "FP_DepthCondition") {
+        FP_DepthCondition = std::stoi(bits[4]);
+    } else if(name == "FP_Base") {
+        FP_Base = std::stoi(bits[4]);
+    } else if(name == "FP_Multiplier") {
+        FP_Multiplier = std::stoi(bits[4]);
+    } else if(name == "LMP_DepthCondition") {
+        LMP_DepthCondition = std::stoi(bits[4]);
+    } else if(name == "LMP_Base") {
+        LMP_Base = std::stoi(bits[4]);
+    } else if(name == "SPR_DepthCondition") {
+        SPR_DepthCondition = std::stoi(bits[4]);
+    } else if(name == "SPR_CaptureThreshold") {
+        SPR_CaptureThreshold = -std::stoi(bits[4]);
+    } else if(name == "SPR_QuietThreshold") {
+        SPR_QuietThreshold = -std::stoi(bits[4]);
+    } else if(name == "NMP_Adder") {
+        NMP_Adder = std::stoi(bits[4]);
+    } else if(name == "NMP_Divisor") {
+        NMP_Divisor = std::stoi(bits[4]);
+    } else if(name == "NMP_Subtractor") {
+        NMP_Subtractor = std::stoi(bits[4]);
+    } else if(name == "NMP_DepthCondition") {
+        NMP_DepthCondition = std::stoi(bits[4]);
     }
 }
 
@@ -70,6 +135,34 @@ void identify() {
     std::cout << "id name Clarity V3.0.0\n";
     std::cout << "id author Vast\n";
     std::cout << "option name Hash type spin default 64 min 1 max 2048\n";
+    std::cout << "option name lmrBase type spin default 77 min 0 max 200\n";
+    std::cout << "option name lmrMultiplier type spin default 42 min 0 max 70\n";
+    std::cout << "option name hardBoundDivisor type spin default 2 min 0 max 10\n";
+    std::cout << "option name softBoundNumerator type spin default 3 min 0 max 10\n";
+    std::cout << "option name softBoundDenominator type spin default 4 min 0 max 10\n";
+    std::cout << "option name softBoundMultiplier type spin default 60 min 0 max 100\n";
+    std::cout << "option name defaultMovesToGo type spin default 20 min 0 max 40\n";
+    std::cout << "option name ASP_BaseDelta type spin default 25 min 0 max 100\n";
+    std::cout << "option name ASP_DeltaMultiplier type spin default 15 min 0 max 40\n";
+    std::cout << "option name ASP_DepthCondition type spin default 3 min 0 max 10\n";
+    std::cout << "option name MVV_VictimScoreMultiplier type spin default 500 min 0 max 1000\n";
+    std::cout << "option name FirstKillerScore type spin default 54 min 0 max 100\n";
+    std::cout << "option name SecondKillerScore type spin default 53 min 0 max 100\n";
+    std::cout << "option name RFP_DepthCondition type spin default 9 min 0 max 20\n";
+    std::cout << "option name RFP_Multiplier type spin default 80 min 0 max 120\n";
+    std::cout << "option name IIR_DepthCondition type spin default 3 min 0 max 20\n";
+    std::cout << "option name FP_DepthCondition type spin default 8 min 0 max 20\n";
+    std::cout << "option name FP_Base type spin default 250 min 0 max 400\n";
+    std::cout << "option name FP_Multiplier type spin default 60 min 0 max 100\n";
+    std::cout << "option name LMP_DepthCondition type spin default 7 min 0 max 20\n";
+    std::cout << "option name LMP_Base type spin default 5 min 0 max 20\n";
+    std::cout << "option name SPR_DepthCondition type spin default 8 min 0 max 20\n";
+    std::cout << "option name SPR_CaptureThreshold type spin default 90 min 0 max 200\n";
+    std::cout << "option name SPR_QuietThreshold type spin default 50 min 0 max 200\n";
+    std::cout << "option name NMP_Adder type spin default 1 min 0 max 15\n";
+    std::cout << "option name NMP_Divisor type spin default 3 min 0 max 10\n";
+    std::cout << "option name NMP_Subtractor type spin default 2 min 0 max 10\n";
+    std::cout << "option name NMP_DepthCondition type spin default 2 min 0 max 20\n";
     std::cout << "uciok\n";
 }
 
@@ -78,7 +171,7 @@ void go(std::vector<std::string> bits) {
     int time = 0;
     int depth = 0;
     int inc = 0;
-    int movestogo = 20;
+    int movestogo = defaultMovesToGo;
     for(int i = 1; i < std::ssize(bits); i+=2) {
         if(bits[i] == "wtime" && board.getColorToMove() == 1) {
             time = std::stoi(bits[i+1]);
@@ -106,8 +199,8 @@ void go(std::vector<std::string> bits) {
     } else {
         // go wtime x btime x
         // the formulas here are former formulas from Stormphrax
-        const int softBound = 0.6 * (time / movestogo + inc * 3 / 4);
-        const int hardBound = time / 2;
+        const int softBound = softBoundMultiplier * (time / movestogo + inc * softBoundFractionNumerator / softBoundFractionDenominator);
+        const int hardBound = time / hardBoundDivisor;
         bestMove = engine.think(board, softBound, hardBound, true);
     }
     std::cout << "bestmove " << toLongAlgebraic(bestMove) << '\n';

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -70,10 +70,6 @@ void setOption(const std::vector<std::string>& bits) {
         ASP_DepthCondition = std::stoi(bits[4]);
     } else if(name == "MVV_VictimScoreMultiplier") {
         MVV_VictimScoreMultiplier = std::stoi(bits[4]);
-    } else if(name == "FirstKillerScore") {
-        FirstKillerScore = std::stoi(bits[4]) * 1000;
-    } else if(name == "SecondKillerScore") {
-        SecondKillerScore = std::stoi(bits[4]) * 1000;
     } else if(name == "RFP_DepthCondition") {
         RFP_DepthCondition = std::stoi(bits[4]);
     } else if(name == "RFP_Multiplier") {
@@ -104,6 +100,8 @@ void setOption(const std::vector<std::string>& bits) {
         NMP_Subtractor = std::stoi(bits[4]);
     } else if(name == "NMP_DepthCondition") {
         NMP_DepthCondition = std::stoi(bits[4]);
+    } else {
+        std::cout << "Invalid Option" << std::endl;
     }
 }
 
@@ -138,16 +136,14 @@ void identify() {
     std::cout << "option name lmrBase type spin default 77 min 0 max 200\n";
     std::cout << "option name lmrMultiplier type spin default 42 min 0 max 70\n";
     std::cout << "option name hardBoundDivisor type spin default 2 min 0 max 10\n";
-    std::cout << "option name softBoundNumerator type spin default 3 min 0 max 10\n";
-    std::cout << "option name softBoundDenominator type spin default 4 min 0 max 10\n";
+    std::cout << "option name softBoundFractionNumerator type spin default 3 min 0 max 10\n";
+    std::cout << "option name softBoundFractionDenominator type spin default 4 min 0 max 10\n";
     std::cout << "option name softBoundMultiplier type spin default 60 min 0 max 100\n";
     std::cout << "option name defaultMovesToGo type spin default 20 min 0 max 40\n";
     std::cout << "option name ASP_BaseDelta type spin default 25 min 0 max 100\n";
     std::cout << "option name ASP_DeltaMultiplier type spin default 15 min 0 max 40\n";
     std::cout << "option name ASP_DepthCondition type spin default 3 min 0 max 10\n";
     std::cout << "option name MVV_VictimScoreMultiplier type spin default 500 min 0 max 1000\n";
-    std::cout << "option name FirstKillerScore type spin default 54 min 0 max 100\n";
-    std::cout << "option name SecondKillerScore type spin default 53 min 0 max 100\n";
     std::cout << "option name RFP_DepthCondition type spin default 9 min 0 max 20\n";
     std::cout << "option name RFP_Multiplier type spin default 80 min 0 max 120\n";
     std::cout << "option name IIR_DepthCondition type spin default 3 min 0 max 20\n";

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -54,10 +54,6 @@ void setOption(const std::vector<std::string>& bits) {
         calculateReductions();
     } else if(name == "hardBoundDivisor") {
         hardBoundDivisor = std::stoi(bits[4]);
-    } else if(name == "softBoundFractionNumerator") {
-        softBoundFractionNumerator = std::stoi(bits[4]);
-    } else if(name == "softBoundFractionDenominator") {
-        softBoundFractionDenominator = std::stoi(bits[4]);
     } else if(name == "softBoundMultiplier") {
         softBoundMultiplier = std::stod(bits[4]) / 100;
     } else if(name == "defaultMovesToGo") {
@@ -92,14 +88,10 @@ void setOption(const std::vector<std::string>& bits) {
         SPR_CaptureThreshold = -std::stoi(bits[4]);
     } else if(name == "SPR_QuietThreshold") {
         SPR_QuietThreshold = -std::stoi(bits[4]);
-    } else if(name == "NMP_Adder") {
-        NMP_Adder = std::stoi(bits[4]);
     } else if(name == "NMP_Divisor") {
         NMP_Divisor = std::stoi(bits[4]);
     } else if(name == "NMP_Subtractor") {
         NMP_Subtractor = std::stoi(bits[4]);
-    } else if(name == "NMP_DepthCondition") {
-        NMP_DepthCondition = std::stoi(bits[4]);
     } else {
         std::cout << "Invalid Option" << std::endl;
     }
@@ -136,10 +128,7 @@ void identify() {
     std::cout << "option name lmrBase type spin default 77 min 0 max 200\n";
     std::cout << "option name lmrMultiplier type spin default 42 min 0 max 70\n";
     std::cout << "option name hardBoundDivisor type spin default 2 min 0 max 10\n";
-    std::cout << "option name softBoundFractionNumerator type spin default 3 min 0 max 10\n";
-    std::cout << "option name softBoundFractionDenominator type spin default 4 min 0 max 10\n";
     std::cout << "option name softBoundMultiplier type spin default 60 min 0 max 100\n";
-    std::cout << "option name defaultMovesToGo type spin default 20 min 0 max 40\n";
     std::cout << "option name ASP_BaseDelta type spin default 25 min 0 max 100\n";
     std::cout << "option name ASP_DeltaMultiplier type spin default 15 min 0 max 40\n";
     std::cout << "option name ASP_DepthCondition type spin default 3 min 0 max 10\n";
@@ -155,10 +144,8 @@ void identify() {
     std::cout << "option name SPR_DepthCondition type spin default 8 min 0 max 20\n";
     std::cout << "option name SPR_CaptureThreshold type spin default 90 min 0 max 200\n";
     std::cout << "option name SPR_QuietThreshold type spin default 50 min 0 max 200\n";
-    std::cout << "option name NMP_Adder type spin default 1 min 0 max 15\n";
-    std::cout << "option name NMP_Divisor type spin default 3 min 0 max 10\n";
-    std::cout << "option name NMP_Subtractor type spin default 2 min 0 max 10\n";
-    std::cout << "option name NMP_DepthCondition type spin default 2 min 0 max 20\n";
+    std::cout << "option name NMP_Divisor type spin default 200 min 150 max 250\n";
+    std::cout << "option name NMP_Subtractor type spin default 3 min 0 max 5\n";
     std::cout << "uciok\n";
 }
 


### PR DESCRIPTION
Clang is now the preferred compiler, since the autovectoring is good enough that at short time controls (8+0.08 in this case), the testing went like this:
```
Score of Clarity Current Dev vs Clarity V3.0.5: 99 - 12 - 84  [0.723] 195
...      Clarity Current Dev playing White: 72 - 1 - 25  [0.862] 98
...      Clarity Current Dev playing Black: 27 - 11 - 59  [0.582] 97
...      White vs Black: 83 - 28 - 84  [0.641] 195
Elo difference: 166.7 +/- 37.2, LOS: 100.0 %, DrawRatio: 43.1 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
```