### PR TITLE
"Not as bad as i thought it'd be" extension

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -41,6 +41,7 @@ struct StackEntry {
     // excluded move
     Move excluded;
     int doubleExtensions;
+    int reduction;
 };
 
 struct Engine {


### PR DESCRIPTION
```Elo   | 1.64 +- 1.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 76014 W: 17048 L: 16690 D: 42276
Penta | [437, 8885, 19032, 9189, 464]```
<https://chess.aronpetkovski.com/test/8699/>